### PR TITLE
Don't use macros if they are not needed

### DIFF
--- a/spec/toro_spec.cr
+++ b/spec/toro_spec.cr
@@ -340,6 +340,6 @@ describe "json method helper" do
   end
 
   it "should return json {\"hello\":\"world\"}" do
-    assert_equal "{\"hello\":\"world\"}\n", response.body
+    assert_equal "{\"hello\":\"world\"}", response.body
   end
 end

--- a/src/toro.cr
+++ b/src/toro.cr
@@ -131,33 +131,33 @@ module Toro
       default { {{yield}} } if root?
     end
 
-    macro status
+    def status
       context.response.status_code
     end
 
-    macro status(code)
-      context.response.status_code = {{code}}
+    def status(code)
+      context.response.status_code = code
     end
 
-    macro header(name, value)
-      context.response.headers[{{name}}] = {{value}}
+    def header(name, value)
+      context.response.headers[name] = value
     end
 
-    macro content_type(type)
-      context.response.content_type = {{type}}
+    def content_type(type)
+      context.response.content_type = type
     end
 
-    macro write(str)
-      context.response.puts({{str}})
+    def write(str)
+      context.response.puts(str)
     end
 
     macro render(template)
       ECR.embed "#{ {{template}} }.ecr", context.response
     end
 
-    macro text(str)
+    def text(str)
       header "Content-Type", "text/plain"
-      write {{str}}
+      write str
     end
 
     macro html(template)
@@ -165,14 +165,14 @@ module Toro
       render {{template}}
     end
 
-    macro json(response)
+    def json(response)
       header "Content-Type", "application/json"
-      write {{response}}.to_json
+      response.to_json(context.response)
     end
 
-    macro redirect(url)
+    def redirect(url)
       status 302
-      header "Location", {{url}}
+      header "Location", url
     end
 
     abstract def routes


### PR DESCRIPTION
Hi!

Really nice project! 👍 

In this PR I make some macros be regular methods. The rule about using macros is always: if there's no need to use macro, don't use them. Macros need to be used in some places, for example to have `return` be injected in code (something that's not possible to do in Ruby or other languages, for example), but in many other places there's really no need to use them.

I also changed `json` to stream the json directly to the response, which should result in less memory consumed, and probably faster execution.

A question: should `write` maybe invoke `print`? If I do `text "Hello world"` the output ends up having a newline. Maybe just define `puts` and `print` instead of `write`? In any case, that newline probably doesn't bother.
