### PR TITLE
Removed redundent 'default' macro.

### DIFF
--- a/src/toro.cr
+++ b/src/toro.cr
@@ -80,11 +80,6 @@ module Toro
       end
     end
 
-    macro default
-      {{yield}}
-      return
-    end
-
     def on?(cond : Bool)
       cond
     end


### PR DESCRIPTION
Hello,

I was reading through Toro and noticed the `macro default` definition snuck in there a second time. Pretty minor thing but I've never contributed to anything before and thought I'd give it a try.

Tests are passing ;)

Steve
