### PR TITLE
Add crystal 1.x support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -16,4 +16,4 @@ development_dependencies:
     github: emancu/crotest
     version: ~> 1.0.1
 
-crystal: "0.36.1, ~> 1.0.0"
+crystal: 1.0.0


### PR DESCRIPTION
Hi @soveran,

The advice I gave you in https://github.com/the-benchmarker/web-frameworks/pull/4098#issuecomment-813210539 is wrong .

To add `crystal` **1.x**, we have to set `crystal: 1.0.0` in `shards.yml` (this is the same for https://github.com/soveran/seg).

Adding `crystal` version in `shards.yml` will be resolved as `>=1 && <2`.

Regards,